### PR TITLE
disable side menu when not authenticated

### DIFF
--- a/src/app/RootNavigator.tsx
+++ b/src/app/RootNavigator.tsx
@@ -26,12 +26,13 @@ import { useAuth } from "src/auth"
 
 export const RootNavigator = () => {
   const auth = useAuth()
+  const isLoggedOut = auth.user?.role === undefined
   const handleLogout = auth.logout
 
   return (
     <IonReactRouter>
       {/* MENU */}
-      <IonMenu contentId="main">
+      <IonMenu contentId="main" disabled={isLoggedOut}>
         <IonHeader>
           <IonToolbar>
             <IonTitle>Menu</IonTitle>


### PR DESCRIPTION
This PR makes sure the user can't open the menu when they're on the login screen (i.e. not authenticated)